### PR TITLE
fix(analytics): do not throw on invalid events or paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.13.1
+[FIX] Analytics `sendEvent` / path-journey validation no longer throw; invalid events are logged and skipped so host apps are not interrupted
+
 ## 4.13.0
 [FEA] Added optional parameter `category_id` from `recipe.add`
 

--- a/mealz-shared-analytics/src/commonMain/kotlin/mealz/ai/AbstractSharedAnalytics.kt
+++ b/mealz-shared-analytics/src/commonMain/kotlin/mealz/ai/AbstractSharedAnalytics.kt
@@ -69,8 +69,13 @@ abstract class AbstractSharedAnalytics {
     internal fun buildAndSendPlausibleRequest(eventType: String, path: String, journey: String, props: PlatformMap<String, String?>) {
         if (!alreadyInitialized) return LogHandler.warn("Tried to send event before analytics initialization")
 
-        validatePath(path)
-        validateJourney(journey)
+        try {
+            validatePath(path)
+            validateJourney(journey)
+        } catch (exception: IllegalArgumentException) {
+            LogHandler.warn(exception.message ?: "Invalid analytics path or journey")
+            return
+        }
 
         props["client_sdk_version"] = clientSDKVersion
         props["analytics_sdk_version"] = analyticsSDKVersion

--- a/mealz-shared-analytics/src/commonMain/kotlin/mealz/ai/EventService.kt
+++ b/mealz-shared-analytics/src/commonMain/kotlin/mealz/ai/EventService.kt
@@ -1,23 +1,33 @@
 package ai.mealz.analytics
 
+import ai.mealz.analytics.handler.LogHandler
 import ai.mealz.analytics.utils.PlatformList
 import ai.mealz.analytics.utils.PlatformMap
 
 object EventService : EventSender {
     override fun sendEvent(name: String, path: String, journey: String, props: PlatformMap<String, String?>) {
-        PROPS_FOR_EVENT[name]?.let { propsForEvent ->
-            propsForEvent["mandatory"]?.let { mandatoryProps ->
-                if (!props.areValidForEvent(mandatoryProps)) {
-                    error("Invalid props for $name event : mandatory props are $mandatoryProps and optional props are ${propsForEvent["optional"]}")
-                }
-                SharedAnalytics.sendPlausibleRequest(
-                    name,
-                    path,
-                    journey,
-                    props
-                )
-            } ?: error("No mandatory props found for $name")
-        } ?: error("Unknown event $name")
+        val propsForEvent = PROPS_FOR_EVENT[name]
+        if (propsForEvent == null) {
+            LogHandler.warn("Unknown event $name")
+            return
+        }
+        val mandatoryProps = propsForEvent["mandatory"]
+        if (mandatoryProps == null) {
+            LogHandler.error("No mandatory props found for $name")
+            return
+        }
+        if (!props.areValidForEvent(mandatoryProps)) {
+            LogHandler.warn(
+                "Invalid props for $name event : mandatory props are $mandatoryProps and optional props are ${propsForEvent["optional"]}"
+            )
+            return
+        }
+        SharedAnalytics.sendPlausibleRequest(
+            name,
+            path,
+            journey,
+            props
+        )
     }
 
     private val PROPS_FOR_EVENT = PlatformMap(


### PR DESCRIPTION
## Description

Les validations analytics (événement inconnu, props manquantes, path/journey invalides) ne lèvent plus d'exception : elles sont loguées et ignorées pour ne pas interrompre les apps hôtes (web/mobile).

Related PR:
- https://gitlab.com/miam/mealz-components/-/merge_requests/631
- https://gitlab.com/miam/mealz-ssr-api/-/merge_requests/605

ClickUp task: https://app.clickup.com/t/86cakdafw

### Type of change
- [x] FIX

## Screenshots or recordings
N/A

## Tests ran
**Test configuration**
- `./gradlew :mealz-shared-analytics:compileKotlinJs` — BUILD SUCCESSFUL

**How to test**
1. Checkout `fix/analytics-ssr-v3-non-blocking`
2. Compiler le module JS
3. Vérifier qu'un `sendEvent` avec un nom d'événement inconnu ou un path invalide ne throw pas (log WARN/ERROR uniquement)

## Checklist
- [ ] Self-reviewed code
- [ ] New documentation added
- [x] Added unit tests (N/A — pas de commonTest existant ; couverture côté consumers)
- [x] New and existing tests passed (compile OK)