### PR TITLE
revert: undo mistaken merge of fix/analytics-ssr-v3-non-blocking into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-## 4.13.1
-[FIX] Analytics `sendEvent` / path-journey validation no longer throw; invalid events are logged and skipped so host apps are not interrupted
-
 ## 4.13.0
 [FEA] Added optional parameter `category_id` from `recipe.add`
 

--- a/mealz-shared-analytics/src/commonMain/kotlin/mealz/ai/AbstractSharedAnalytics.kt
+++ b/mealz-shared-analytics/src/commonMain/kotlin/mealz/ai/AbstractSharedAnalytics.kt
@@ -69,13 +69,8 @@ abstract class AbstractSharedAnalytics {
     internal fun buildAndSendPlausibleRequest(eventType: String, path: String, journey: String, props: PlatformMap<String, String?>) {
         if (!alreadyInitialized) return LogHandler.warn("Tried to send event before analytics initialization")
 
-        try {
-            validatePath(path)
-            validateJourney(journey)
-        } catch (exception: IllegalArgumentException) {
-            LogHandler.warn(exception.message ?: "Invalid analytics path or journey")
-            return
-        }
+        validatePath(path)
+        validateJourney(journey)
 
         props["client_sdk_version"] = clientSDKVersion
         props["analytics_sdk_version"] = analyticsSDKVersion

--- a/mealz-shared-analytics/src/commonMain/kotlin/mealz/ai/EventService.kt
+++ b/mealz-shared-analytics/src/commonMain/kotlin/mealz/ai/EventService.kt
@@ -1,33 +1,23 @@
 package ai.mealz.analytics
 
-import ai.mealz.analytics.handler.LogHandler
 import ai.mealz.analytics.utils.PlatformList
 import ai.mealz.analytics.utils.PlatformMap
 
 object EventService : EventSender {
     override fun sendEvent(name: String, path: String, journey: String, props: PlatformMap<String, String?>) {
-        val propsForEvent = PROPS_FOR_EVENT[name]
-        if (propsForEvent == null) {
-            LogHandler.warn("Unknown event $name")
-            return
-        }
-        val mandatoryProps = propsForEvent["mandatory"]
-        if (mandatoryProps == null) {
-            LogHandler.error("No mandatory props found for $name")
-            return
-        }
-        if (!props.areValidForEvent(mandatoryProps)) {
-            LogHandler.warn(
-                "Invalid props for $name event : mandatory props are $mandatoryProps and optional props are ${propsForEvent["optional"]}"
-            )
-            return
-        }
-        SharedAnalytics.sendPlausibleRequest(
-            name,
-            path,
-            journey,
-            props
-        )
+        PROPS_FOR_EVENT[name]?.let { propsForEvent ->
+            propsForEvent["mandatory"]?.let { mandatoryProps ->
+                if (!props.areValidForEvent(mandatoryProps)) {
+                    error("Invalid props for $name event : mandatory props are $mandatoryProps and optional props are ${propsForEvent["optional"]}")
+                }
+                SharedAnalytics.sendPlausibleRequest(
+                    name,
+                    path,
+                    journey,
+                    props
+                )
+            } ?: error("No mandatory props found for $name")
+        } ?: error("Unknown event $name")
     }
 
     private val PROPS_FOR_EVENT = PlatformMap(


### PR DESCRIPTION
## Summary
- Revert du merge accidentel de `#113` (`fix/analytics-ssr-v3-non-blocking`) dans `main` au lieu de `develop`
- Remet `main` à l’état post-release `4.13.0` (sans le fix non-blocking)

## Context
La PR #113 a été mergée dans `main` par erreur. Le fix doit aller dans `develop` (PR sœur).

## Test plan
- [ ] Vérifier que le diff annule bien les changements de `#113`
- [ ] Confirmer qu’aucun tag/release n’inclut encore ce merge (aucun tag ne contient `3e9fe66`)