### PR TITLE
fix(analytics): do not throw on invalid events or paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.13.1
+[FIX] Analytics `sendEvent` / path-journey validation no longer throw; invalid events are logged and skipped so host apps are not interrupted
+
 ## 4.13.0
 [FEA] Added optional parameter `category_id` from `recipe.add`
 

--- a/mealz-shared-analytics/src/commonMain/kotlin/mealz/ai/AbstractSharedAnalytics.kt
+++ b/mealz-shared-analytics/src/commonMain/kotlin/mealz/ai/AbstractSharedAnalytics.kt
@@ -69,8 +69,13 @@ abstract class AbstractSharedAnalytics {
     internal fun buildAndSendPlausibleRequest(eventType: String, path: String, journey: String, props: PlatformMap<String, String?>) {
         if (!alreadyInitialized) return LogHandler.warn("Tried to send event before analytics initialization")
 
-        validatePath(path)
-        validateJourney(journey)
+        try {
+            validatePath(path)
+            validateJourney(journey)
+        } catch (exception: IllegalArgumentException) {
+            LogHandler.warn(exception.message ?: "Invalid analytics path or journey")
+            return
+        }
 
         props["client_sdk_version"] = clientSDKVersion
         props["analytics_sdk_version"] = analyticsSDKVersion

--- a/mealz-shared-analytics/src/commonMain/kotlin/mealz/ai/EventService.kt
+++ b/mealz-shared-analytics/src/commonMain/kotlin/mealz/ai/EventService.kt
@@ -1,23 +1,33 @@
 package ai.mealz.analytics
 
+import ai.mealz.analytics.handler.LogHandler
 import ai.mealz.analytics.utils.PlatformList
 import ai.mealz.analytics.utils.PlatformMap
 
 object EventService : EventSender {
     override fun sendEvent(name: String, path: String, journey: String, props: PlatformMap<String, String?>) {
-        PROPS_FOR_EVENT[name]?.let { propsForEvent ->
-            propsForEvent["mandatory"]?.let { mandatoryProps ->
-                if (!props.areValidForEvent(mandatoryProps)) {
-                    error("Invalid props for $name event : mandatory props are $mandatoryProps and optional props are ${propsForEvent["optional"]}")
-                }
-                SharedAnalytics.sendPlausibleRequest(
-                    name,
-                    path,
-                    journey,
-                    props
-                )
-            } ?: error("No mandatory props found for $name")
-        } ?: error("Unknown event $name")
+        val propsForEvent = PROPS_FOR_EVENT[name]
+        if (propsForEvent == null) {
+            LogHandler.warn("Unknown event $name")
+            return
+        }
+        val mandatoryProps = propsForEvent["mandatory"]
+        if (mandatoryProps == null) {
+            LogHandler.error("No mandatory props found for $name")
+            return
+        }
+        if (!props.areValidForEvent(mandatoryProps)) {
+            LogHandler.warn(
+                "Invalid props for $name event : mandatory props are $mandatoryProps and optional props are ${propsForEvent["optional"]}"
+            )
+            return
+        }
+        SharedAnalytics.sendPlausibleRequest(
+            name,
+            path,
+            journey,
+            props
+        )
     }
 
     private val PROPS_FOR_EVENT = PlatformMap(


### PR DESCRIPTION
## Summary
- Cherry-pick du fix `#113` vers `develop` (cible correcte)
- `sendEvent` / validation path-journey ne throw plus : events invalides loggés et skippés

## Context
Correction suite au merge accidentel dans `main`. Une PR de revert retire le fix de `main` ; celle-ci l’applique sur `develop`.

## Test plan
- [ ] Diff aligné avec `#113` / commit `8892d33`
- [ ] Pas d’impact sur le comportement nominal des events valides